### PR TITLE
chore: Add jest-useragent-mock to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "main": "dist/cjs/index.js",
   "types": "./dist/esm/index.d.ts",
   "dependencies": {
-    "is-hotkey": "^0.2.0"
+    "is-hotkey": "^0.2.0",
+    "jest-useragent-mock": "^0.1.1",
   },
   "peerDependencies": {
     "@testing-library/jest-dom": "^5.15.0",
@@ -48,7 +49,6 @@
     "eslint-plugin-react": "^7.26.1",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-unicorn": "^36.0.0",
-    "jest-useragent-mock": "^0.1.1",
     "lodash.clonedeep": "^4.5.0",
     "prettier": "^2.4.1",
     "react": ">=16.8.0",


### PR DESCRIPTION
Hey! Nice library.
I think that `jest-useragent-mock` should be among the dependencies (or at least `peerDependencies`) because it's used [here](https://github.com/mwood23/slate-test-utils/blob/1d47b1d09c2fe12d92d3823861af9ed0f245a683/src/testRunner.ts#L2). I haven't been able to use the library without adding this to the dependencies myself.