### PR TITLE
Modify pressEnter, allowing real Enter calls

### DIFF
--- a/src/buildTestHarness.tsx
+++ b/src/buildTestHarness.tsx
@@ -251,10 +251,7 @@ export const buildTestHarness =
      */
     const pressEnter = async () =>
       act(async () => {
-        fireEvent(
-          element,
-          new InputEvent('beforeinput', { inputType: 'insertLineBreak' }),
-        )
+        await triggerKeyboardEvent('Enter')
       })
 
     /**


### PR DESCRIPTION
When adopting `slate-test-utils` I noticed invoking `pressEnter` wasn't actually triggering the logic that we run in a plugin that fires ... on Enter.

It turns out the older code was inserting line breaks which !== pressing enter.

Simulating [Enter] is as easy as calling `triggerKeyboardEvent('Enter')` though!