### PR TITLE
Add support for new paste function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist
 node_modules
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ deleteHardLineForward: () => Promise<void>
 deleteSoftLineForward: () => Promise<void>
 deleteWordBackward: () => Promise<void>
 deleteWordForward: () => Promise<void>
-paste: (payload: string, { types: 'text/html' | 'text/plain' | 'image/png'[] }) => Promise<void>
+paste: (payload: string, ?{ types: 'text/html' | 'text/plain' | 'image/png'[] }) => Promise<void>
 pressEnter: () => Promise<void>
 /**
  * Use a hotkey combination from is-hotkey. See testHarness internals

--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ deleteHardLineForward: () => Promise<void>
 deleteSoftLineForward: () => Promise<void>
 deleteWordBackward: () => Promise<void>
 deleteWordForward: () => Promise<void>
+paste: (payload: string, { types: 'text/html' | 'text/plain' | 'image/png'[] }) => Promise<void>
 pressEnter: () => Promise<void>
 /**
  * Use a hotkey combination from is-hotkey. See testHarness internals

--- a/src/buildTestHarness.tsx
+++ b/src/buildTestHarness.tsx
@@ -25,7 +25,7 @@ export type RenderEditorReturnTuple = [
     deleteSoftLineForward: () => Promise<void>
     deleteWordBackward: () => Promise<void>
     deleteWordForward: () => Promise<void>
-    paste: (payload: string, options: PasteOptions) => Promise<void>
+    paste: (payload: string, options?: PasteOptions) => Promise<void>
     pressEnter: () => Promise<void>
     /**
      * Use a hotkey combination from is-hotkey. See testHarness internals
@@ -146,9 +146,12 @@ export const buildTestHarness =
 
     const typeSpace = async () => type(' ')
 
-    const paste = async (payload: string, options: PasteOptions = {}) =>
+    const paste = async (
+      payload: string,
+      options: PasteOptions | undefined = {},
+    ) =>
       act(async () => {
-        const types = options.types ?? ['text/html']
+        const types = options?.types ?? ['text/html']
 
         const event = new window.Event('paste', {
           bubbles: true,

--- a/src/buildTestHarness.tsx
+++ b/src/buildTestHarness.tsx
@@ -9,6 +9,9 @@ import { ComponentType } from 'react'
 import { HistoryEditor } from 'slate-history'
 import { ensureSlateStateValid } from './ensureSlateValid'
 
+type ClipboardDataType = 'text/html' | 'text/plain' | 'image/png'
+type PasteOptions = { types?: ClipboardDataType[] }
+
 export type RenderEditorReturnTuple = [
   editor: Editor,
   commands: {
@@ -22,6 +25,7 @@ export type RenderEditorReturnTuple = [
     deleteSoftLineForward: () => Promise<void>
     deleteWordBackward: () => Promise<void>
     deleteWordForward: () => Promise<void>
+    paste: (payload: string, options: PasteOptions) => Promise<void>
     pressEnter: () => Promise<void>
     /**
      * Use a hotkey combination from is-hotkey. See testHarness internals
@@ -141,6 +145,27 @@ export const buildTestHarness =
       })
 
     const typeSpace = async () => type(' ')
+
+    const paste = async (payload: string, options: PasteOptions = {}) =>
+      act(async () => {
+        const types = options.types ?? ['text/html']
+
+        const event = new window.Event('paste', {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+        })
+
+        // @ts-ignore Typescript doesn't expect clipboardData on Event type
+        event.clipboardData = {
+          types,
+          getData() {
+            return payload
+          },
+        }
+
+        fireEvent(element, event)
+      })
 
     /**
      * Deletes forward one character from the current Slate selection.
@@ -305,6 +330,7 @@ export const buildTestHarness =
         deleteWordBackward,
         deleteWordForward,
         triggerKeyboardEvent,
+        paste,
         pressEnter,
         typeSpace,
         undo,


### PR DESCRIPTION
This PR adds support for broadcasting `paste` events that slate-react properly receives and handles to various `insertData` functions.

My test looks like this:
```ts
import { assertOutput, buildTestHarness } from 'slate-test-utils';
import { jsx as h } from 'slate-hyperscript';

import TextEditor from '..';

it('user copy and pastes link', async () => {
  const input = h('editor', [h('element', { type: 'paragraph' }, [h('text', [h('cursor')])])]);

  const [editor, { paste }] = await buildTestHarness(TextEditor)({
    editor: input,
  });

  await paste('foo!');

  assertOutput(
    editor,
    h('editor', [h('element', { type: 'paragraph' }, [h('text', ['foo!', h('cursor')])])]),
  );
});
```

![image](https://user-images.githubusercontent.com/2148168/145870637-de691a67-dfab-44ce-a708-d5c9be395baf.png)
